### PR TITLE
Increase hit area for file multi-selection checkboxes

### DIFF
--- a/frontend/src/FileManager/FileList/FileItem.jsx
+++ b/frontend/src/FileManager/FileList/FileItem.jsx
@@ -212,6 +212,7 @@ const FileItem = ({
             id={file.name}
             checked={fileSelected}
             className={`selection-checkbox ${checkboxClassName}`}
+            labelClassName={`selection-checkbox-label`}
             onChange={handleCheckboxChange}
             onClick={(e) => e.stopPropagation()}
           />

--- a/frontend/src/FileManager/FileList/FileList.scss
+++ b/frontend/src/FileManager/FileList/FileList.scss
@@ -67,10 +67,15 @@
       background-color: $item-hover-color;
     }
 
-    .selection-checkbox {
+    .selection-checkbox-label {
       position: absolute;
-      left: 5px;
-      top: 8px;
+      top: 0;
+      left: 0;
+      padding: 8px 5px;
+    }
+
+    .selection-checkbox {
+      position: static;
     }
 
     .hidden {
@@ -199,8 +204,13 @@
       background-color: unset;
     }
 
+    .selection-checkbox-label {
+      padding-top: 12px;
+      padding-bottom: 12px;
+    }
+
     .selection-checkbox {
-      top: 12px;
+      position: static;
     }
 
     .file-name {

--- a/frontend/src/components/Checkbox/Checkbox.jsx
+++ b/frontend/src/components/Checkbox/Checkbox.jsx
@@ -1,18 +1,19 @@
 import "./Checkbox.scss";
 
-const Checkbox = ({ name, id, checked, onClick, onChange, className = "", title, disabled = false }) => {
+const Checkbox = ({ name, id, checked, onClick, onChange, className = "", labelClassName = "", title, disabled = false }) => {
   return (
-    <input
-      className={`fm-checkbox ${className}`}
-      type="checkbox"
-      name={name}
-      id={id}
-      checked={checked}
-      onClick={onClick}
-      onChange={onChange}
-      title={title}
-      disabled={disabled}
-    />
+    <label htmlFor={id} aria-label={`${name} checkbox`} onClick={onClick} className={labelClassName}>
+      <input
+        className={`fm-checkbox ${className}`}
+        type="checkbox"
+        name={name}
+        id={id}
+        checked={checked}
+        onChange={onChange}
+        title={title}
+        disabled={disabled}
+      />
+    </label>
   );
 };
 


### PR DESCRIPTION
### Summary

Default checkboxes are now wrapped by a padded label, as indicated in the screenshot below (purple is clickable).

<img width="221" height="127" alt="image" src="https://github.com/user-attachments/assets/9c2cea38-904c-46b7-9b19-b0462b8560ef" />

### Test Plan

Try to click slightly outside the checkbox at the left of a file entry in the file manager. Multi-selection should still work (i.e. previous file selection is not forgotten). Check the size of the label with Dev tools, and verify that the size is appropriate.

Verify the above in the list and grid views.
