### PR TITLE
Fix support for ctrl-click selection on MacOS

### DIFF
--- a/frontend/src/FileManager/FileList/FileItem.jsx
+++ b/frontend/src/FileManager/FileList/FileItem.jsx
@@ -92,7 +92,9 @@ const FileItem = ({
     e.stopPropagation();
     if (file.isEditing) return;
 
-    handleFileRangeSelection(e.shiftKey, e.ctrlKey);
+    // Crude way to support MacOS: consider the meta key as well (i.e. command key).
+    // See https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/ctrlKey.
+    handleFileRangeSelection(e.shiftKey, e.ctrlKey || e.metaKey);
 
     const currentTime = new Date().getTime();
     if (currentTime - lastClickTime < 300) {


### PR DESCRIPTION
### Summary

The meta key is now also considered for the ctrl-click functionality, which on MacOS is the command key. This is necessary because control+click on MacOS [is intercepted by the OS](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/ctrlKey).

The side-effect is that win+click works for multi-file selection on Windows. I am not sure if it is worth it to somehow detect the OS to determine which key to consider.

### Test Plan

On MacOS, try to select multiple files with the command key (command + left mouse click). The previous file selection should not be forgotten.