### PR TITLE
Fix outdated frontend version

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bmdsoftware/react-file-manager",
-  "version": "1.0.3-beta.1",
+  "version": "1.0.4-beta.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bmdsoftware/react-file-manager",
-      "version": "1.0.3-beta.1",
+      "version": "1.0.4-beta.3",
       "license": "MIT",
       "dependencies": {
         "react-collapsible": "^2.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bmdsoftware/react-file-manager",
   "private": false,
-  "version": "1.0.3-beta.1",
+  "version": "1.0.4-beta.3",
   "type": "module",
   "module": "dist/react-file-manager.es.js",
   "files": [


### PR DESCRIPTION
### Motivation and Context

The frontend package had an outdated version `1.0.3-beta.1`.

### Summary

Bumped the frontend package version to `1.0.4-beta.3`.
