### PR TITLE
Bump frontend version to 1.0.5

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bmdsoftware/react-file-manager",
-  "version": "1.0.4-beta.3",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bmdsoftware/react-file-manager",
-      "version": "1.0.4-beta.3",
+      "version": "1.0.5",
       "license": "MIT",
       "dependencies": {
         "react-collapsible": "^2.10.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bmdsoftware/react-file-manager",
   "private": false,
-  "version": "1.0.4-beta.3",
+  "version": "1.0.5",
   "type": "module",
   "module": "dist/react-file-manager.es.js",
   "files": [


### PR DESCRIPTION
### Motivation and Context

Bump version of the frontend to `1.0.5`.

### Summary

The following PRs were included:
- #3
- #4



