### PR TITLE
Fix date column misalignment for List rows with lengthy names

### DIFF
--- a/frontend/src/FileManager/FileList/FileItem.jsx
+++ b/frontend/src/FileManager/FileList/FileItem.jsx
@@ -187,6 +187,8 @@ const FileItem = ({
     setCheckboxClassName(selectedFileIndexes.includes(index) ? "visible" : "hidden");
   }, [selectedFileIndexes]);
 
+  const [date, time] = formatDate(file.updatedAt, "date-time");
+
   return (
     <div
       className={`file-item-container ${dropZoneClass} ${
@@ -252,7 +254,7 @@ const FileItem = ({
 
       {activeLayout === "list" && (
         <>
-          <div className="modified-date">{formatDate(file.updatedAt)}</div>
+          <div className="modified-date">{date}<br/>{time}</div>
           <div className="size">{file?.size > 0 ? getDataSize(file?.size) : ""}</div>
         </>
       )}

--- a/frontend/src/FileManager/FileList/FileList.scss
+++ b/frontend/src/FileManager/FileList/FileList.scss
@@ -229,7 +229,7 @@
   .modified-date {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: left;
     font-size: 0.8em;
     width: calc(20%);
   }
@@ -237,7 +237,7 @@
   .size {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: left;
     font-size: 0.8em;
     width: calc(10%);
   }

--- a/frontend/src/FileManager/FileList/FileList.scss
+++ b/frontend/src/FileManager/FileList/FileList.scss
@@ -206,7 +206,7 @@
     padding: 15px;
     padding-left: 33px;
     margin: 0;
-    width: calc(70% - 30px);
+    flex-grow: 1;
 
     &:hover {
       background-color: unset;

--- a/frontend/src/utils/formatDate.js
+++ b/frontend/src/utils/formatDate.js
@@ -1,4 +1,4 @@
-export const formatDate = (date) => {
+export const formatDate = (date, type = "string") => {
   if (!date || isNaN(Date.parse(date))) return "";
 
   date = new Date(date);
@@ -11,5 +11,15 @@ export const formatDate = (date) => {
   const day = date.getDate();
   const year = date.getFullYear();
 
-  return `${month}/${day}/${year} ${hours}:${minutes < 10 ? "0" + minutes : minutes} ${ampm}`;
+  const strDate = `${month}/${day}/${year}`;
+  const strTime = `${hours}:${minutes < 10 ? "0" + minutes : minutes} ${ampm}`;
+
+  switch (type) {
+    case "string":
+      return `${strDate} ${strTime}`;
+    case "date-time":
+      return [strDate, strTime];
+    default:
+      throw new Error(`Unsupported format type: ${type}`);
+  }
 };


### PR DESCRIPTION
### Motivation and Context

In the List view, the Modified date column can be misaligned for rows with lengthy names.

### Summary

Make all rows have consistent width. The `width` of the Name column now grows with `flex-grow` instead of having a set width, which was being overridden with an automatically-computed `min-width` value, after shrinking with `flex-shrink`, for rows with lengthy Name values.


