### PR TITLE
Bump frontend version to 1.1.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@bmdsoftware/react-file-manager",
   "private": false,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "module": "dist/react-file-manager.es.js",
   "files": [


### PR DESCRIPTION
### Motivation and Context

Bump version of the frontend to `1.1.1`.

### Summary

The following PRs are included:
- #8
- #9

